### PR TITLE
Make library integrable

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))

--- a/colorizator.py
+++ b/colorizator.py
@@ -7,12 +7,12 @@ from denoising.denoiser import FFDNetDenoiser
 from utils.utils import resize_pad
 
 class MangaColorizator:
-    def __init__(self, device, generator_path = 'networks/generator.zip', extractor_path = 'networks/extractor.pth'):
+    def __init__(self, device, generator_path = 'networks/generator.zip', extractor_path = 'networks/extractor.pth', denoiser_path = 'denoising/models/'):
         self.colorizer = Colorizer().to(device)
         self.colorizer.generator.load_state_dict(torch.load(generator_path, map_location = device))
         self.colorizer = self.colorizer.eval()
         
-        self.denoiser = FFDNetDenoiser(device)
+        self.denoiser = FFDNetDenoiser(device, _weights_dir=denoiser_path)
         
         self.current_image = None
         self.current_hint = None

--- a/denoising/__init__.py
+++ b/denoising/__init__.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))

--- a/networks/__init__.py
+++ b/networks/__init__.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+import sys, os
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))


### PR DESCRIPTION
- consider repo folders as modules, needed for internal calls if execution is from outside
- weights for denoiser can be given as argument of MangaColorizator()